### PR TITLE
Updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{,**/}{actual,fixtures,expected,templates}/**/*.*]
+[{**/{actual,fixtures,expected,templates}/**,*.md}]
 trim_trailing_whitespace = false
 insert_final_newline = false

--- a/examples/helpers.js
+++ b/examples/helpers.js
@@ -2,7 +2,7 @@ require('time-require');
 
 var Engine = require('..');
 var engine = new Engine();
-var helpers = require('template-helpers')._;
+var helpers = require('template-helpers')();
 
 
 engine.helpers(helpers);

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ Engine.prototype.data = function(prop, value) {
  * @return {RegExp}
  */
 
-Engine.prototype._regex = function (opts) {
+Engine.prototype._regex = function(opts) {
   opts = utils.assign({}, this.options, opts);
   if (!opts.interpolate && !opts.regex && !opts.escape && !opts.evaluate) {
     return utils.delimiters;
@@ -197,7 +197,7 @@ Engine.prototype._regex = function (opts) {
  * @api public
  */
 
-Engine.prototype.compile = function (str, options, settings) {
+Engine.prototype.compile = function(str, options, settings) {
   var assign = utils.assign;
   var engine = this;
 
@@ -235,7 +235,7 @@ Engine.prototype.compile = function (str, options, settings) {
   // Compile the regexp to match each delimiter.
   var re = engine._regex(opts);
 
-  str.replace(re, function (match, esc, interp, es6, evaluate, offset) {
+  str.replace(re, function(match, esc, interp, es6, evaluate, offset) {
     if (!interp) interp = es6;
 
     // Escape characters that can't be included in str literals.
@@ -284,7 +284,7 @@ Engine.prototype.compile = function (str, options, settings) {
     + (isEvaluating ? ', __j = Array.prototype.join;\nfunction print() { __p += __j.call(arguments, "") }\n' : ';\n')
     + source + 'return __p\n}';
 
-  var result = utils.tryCatch(function () {
+  var result = utils.tryCatch(function() {
     return Function(keys, sourceURL + 'return ' + source).apply(null, values);
   });
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "assign-deep": "^0.4.5",
-    "collection-visit": "^0.2.1",
+    "collection-visit": "^0.2.3",
     "get-value": "^2.0.6",
     "kind-of": "^3.0.4",
     "lazy-cache": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,24 +23,23 @@
     "test": "mocha"
   },
   "dependencies": {
-    "assign-deep": "^0.4.3",
-    "collection-visit": "^0.2.0",
-    "get-value": "^1.2.1",
-    "kind-of": "^2.0.1",
-    "lazy-cache": "^0.2.3",
+    "assign-deep": "^0.4.5",
+    "collection-visit": "^0.2.1",
+    "get-value": "^2.0.6",
+    "kind-of": "^3.0.4",
+    "lazy-cache": "^2.0.1",
     "object.omit": "^2.0.0",
-    "set-value": "^0.2.0"
+    "set-value": "^0.3.3"
   },
   "devDependencies": {
     "ansi-red": "^0.1.1",
     "extend-shallow": "^2.0.1",
-    "for-in": "^0.1.4",
-    "gulp-format-md": "^0.1.9",
-    "lodash": "^3.10.1",
-    "mocha": "*",
-    "shallow-clone": "^0.1.1",
-    "should": "*",
-    "template-helpers": "^0.3.2",
+    "for-in": "^0.1.5",
+    "gulp-format-md": "^0.1.10",
+    "mocha": "^3.0.1",
+    "shallow-clone": "^0.1.2",
+    "should": "^10.0.0",
+    "template-helpers": "^0.6.7",
     "time-require": "jonschlinkert/time-require"
   },
   "keywords": [

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -8,7 +8,6 @@ var forIn = require('for-in');
 
 var support = module.exports;
 
-
 support.MAX_ARRAY_LENGTH = 4294967295;
 
 /**
@@ -91,7 +90,7 @@ support.times = function times(n, fn, thisArg) {
  */
 
 support.bindCallback = function bindCallback(fn, thisArg, argCount) {
-  if (typeof fn != 'function') {
+  if (typeof fn !== 'function') {
     return support.identity;
   }
   if (thisArg === undefined) {
@@ -119,7 +118,6 @@ support.bindCallback = function bindCallback(fn, thisArg, argCount) {
     return fn.apply(thisArg, arguments);
   };
 };
-
 
 support.each = function each(obj, fn, thisArg) {
   if (Array.isArray(obj)) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,20 +1,19 @@
 'use strict';
 
-/* deps: mocha */
+require('mocha');
+require('should');
 var assert = require('assert');
-var should = require('should');
 var extend = require('extend-shallow');
-var clone = require('shallow-clone')
+var clone = require('shallow-clone');
 var support = require('./support');
 var Engine = require('..');
-var _ = require('lodash');
 var engine;
 
 describe('engine', function() {
   beforeEach(function() {
     engine = new Engine();
     engine.helper('each', support.each);
-  });;
+  });
 
   it('should escape values in "escape" delimiters', function() {
     var strings = ['<p><%- value %></p>', '<p><%-value%></p>', '<p><%-\nvalue\n%></p>'];
@@ -35,8 +34,8 @@ describe('engine', function() {
     + '} %></ul>'
     );
 
-    var data = { 'collection': { 'a': 'A', 'b': 'B' } },
-        actual = compiled(data);
+    var data = { 'collection': { 'a': 'A', 'b': 'B' } };
+    var actual = compiled(data);
 
     assert.strictEqual(actual, '<ul><li>A</li><li>B</li></ul>');
   });
@@ -71,7 +70,7 @@ describe('engine', function() {
     var actual;
     try {
       actual = compiled();
-    } catch(e) {}
+    } catch (e) {}
 
     assert.strictEqual(actual, 'function');
   });
@@ -163,8 +162,8 @@ describe('engine', function() {
         'interpolate': /<\?=([\s\S]+?)\?>/g
       });
 
-      var compiled = engine.compile('<ul><? each(collection, function(value, index) { ?><li><?= index ?>: <?- value ?></li><? }); ?></ul>', index ? null : settings),
-          expected = '<ul><li>0: a &amp; A</li><li>1: b &amp; B</li></ul>';
+      var compiled = engine.compile('<ul><? each(collection, function(value, index) { ?><li><?= index ?>: <?- value ?></li><? }); ?></ul>', index ? null : settings);
+      var expected = '<ul><li>0: a &amp; A</li><li>1: b &amp; B</li></ul>';
       var data = { 'collection': ['a & A', 'b & B'] };
 
       assert.strictEqual(compiled(data), expected);
@@ -185,12 +184,12 @@ describe('engine', function() {
   it('should support the "imports" option', function() {
     engine = new Engine({
       helpers: {
-        foo: function () {},
-        bar: function () {},
-        baz: function () {}
+        foo: function() {},
+        bar: function() {},
+        baz: function() {}
       }
-    })
-    console.log(engine)
+    });
+    console.log(engine);
   });
 
   it('should support the "variable" options', function() {
@@ -204,7 +203,7 @@ describe('engine', function() {
 
     try {
       assert.strictEqual(compiled(data), '123');
-    } catch(e) {
+    } catch (e) {
       assert(false, e.message);
     }
   });
@@ -217,8 +216,8 @@ describe('engine', function() {
   });
 
   it('should use a `with` statement by default', function() {
-    var compiled = engine.compile('<%= index %><%= collection[index] %><% each(collection, function(value, index) { %><%= index %><% }); %>'),
-        actual = compiled({ 'index': 1, 'collection': ['a', 'b', 'c'] });
+    var compiled = engine.compile('<%= index %><%= collection[index] %><% each(collection, function(value, index) { %><%= index %><% }); %>');
+    var actual = compiled({ 'index': 1, 'collection': ['a', 'b', 'c'] });
 
     assert.strictEqual(actual, '1b012');
   });
@@ -280,7 +279,7 @@ describe('engine', function() {
     /*@cc_on @*/
     try {
       compiled();
-    } catch(e) {
+    } catch (e) {
       pass = false;
     }
     assert(pass, true);
@@ -363,7 +362,7 @@ describe('engine', function() {
 
     try {
       engine.compile('')(1);
-    } catch(e) {
+    } catch (e) {
       pass = false;
     }
 
@@ -372,7 +371,7 @@ describe('engine', function() {
 
     try {
       engine.compile('', 1)(1);
-    } catch(e) {
+    } catch (e) {
       pass = false;
     }
     assert(pass, '`options` value');
@@ -392,7 +391,7 @@ describe('engine', function() {
     var source;
     try {
       engine.compile('<% if x %>');
-    } catch(e) {
+    } catch (e) {
       source = e.source;
     }
     assert(source.indexOf('__p') > -1);
@@ -405,7 +404,7 @@ describe('engine', function() {
 
     try {
       engine.compile('<% if x %>', options);
-    } catch(e) {
+    } catch (e) {
       values[1] = e.source;
     }
 
@@ -430,7 +429,8 @@ describe('engine', function() {
   describe('delimiters', function() {
     afterEach(function() {
       Engine.utils.delimiters.lastIndex = 0;
-    })
+    });
+
     it('should be `true` for `<%- foo %>`', function() {
       assert(Engine.utils.delimiters.test('<%- foo %>'));
     });


### PR DESCRIPTION
Update `.editorconfig`
Lint with `eslint`
Update dependencies
- this required changing an example using `template-helpers` due to an api change in `template-helpers`
- no other changes were required for api changes even though there were some dependencies that had major/minor bumps. 
