### PR TITLE
Updated dependency for `assign-deep`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     }
   },
   "dependencies": {
-    "assign-deep": "^1.0.0"
+    "assign-deep": "^1.0.1"
   }
 }


### PR DESCRIPTION
Noticed that `assign-deep` was updated a while back and npm is flagging it.